### PR TITLE
examples: fix build error

### DIFF
--- a/examples/cpp_classification/classification_profiling_schedule.cpp
+++ b/examples/cpp_classification/classification_profiling_schedule.cpp
@@ -89,7 +89,6 @@ Classifier::Classifier(const string& model_file,
   Caffe::set_mode(Caffe::GPU);
 #endif
 
-  AclEnableSchedule();
   /* Load the network. */
   net_.reset(new Net<float>(model_file, TEST));
   net_->CopyTrainedLayersFrom(trained_file);


### PR DESCRIPTION
fixed below build error to classification_profiling_schedule.cpp

/home/abuild/rpmbuild/BUILD/libcoa-v0.4.0/examples/cpp_classification/classification_profiling_schedule.cpp:92: undefined reference to `caffe::AclEnableSchedule(int)'

Calling AclEnableSchedule function isn't required
becasue Caff::set_mode function is called already.

Signed-off-by: Inki Dae <inki.dae@samsung.com>